### PR TITLE
Add with-timing macro.

### DIFF
--- a/src/clj_statsd.clj
+++ b/src/clj_statsd.clj
@@ -61,3 +61,16 @@
   ([k]        (increment k -1 1.0))
   ([k v]      (increment k (* -1 v) 1.0))
   ([k v rate] (increment k (* -1 v) rate)))
+
+(defmacro with-sampled-timing
+  "Time the execution of the provided code, with sampling."
+  [k rate & body]
+  `(let [start# (System/currentTimeMillis)
+         result# (do ~@body)]
+    (timing ~k (- (System/currentTimeMillis) start#) ~rate)
+    result#))
+
+(defmacro with-timing
+  "Time the execution of the provided code."
+  [k & body]
+  `(with-sampled-timing ~k 1.0 ~@body))

--- a/test/clj_statsd/test.clj
+++ b/test/clj_statsd/test.clj
@@ -44,3 +44,17 @@
 (deftest should-not-send-stat-without-cfg
   (with-redefs [cfg (atom nil)]
     (should-send-expected-stat "gorets:1|c" 0 0 (increment "gorets"))))
+
+(deftest should-time-code
+  (let [cnt (atom 0)]
+    (with-redefs [timing
+                  (fn [k v rate]
+                    (is (= "test.time" k))
+                    (is (>= v 200))
+                    (is (= 1.0 rate))
+                    (swap! cnt inc))]
+      (with-timing "test.time"
+        (Thread/sleep 200))
+      (with-sampled-timing "test.time" 1.0
+        (Thread/sleep 200))
+      (is (= @cnt 2)))))


### PR DESCRIPTION
Handles the boilerplate associated with
timing a chunk of code.

(with-timing :foo
  (foo "bar"))
