### PR TITLE
Add a configurable prefix.

### DIFF
--- a/test/clj_statsd/test.clj
+++ b/test/clj_statsd/test.clj
@@ -69,3 +69,10 @@
       (with-sampled-timing "test.time" 1.0
         (Thread/sleep 200))
       (is (= @cnt 2)))))
+
+(deftest should-prefix
+  (with-redefs [cfg (atom nil)]
+    (setup "localhost" 8125 :prefix "test.stats.")
+    (should-send-expected-stat "test.stats.gorets:1|c" 2 2
+      (increment "gorets")
+      (increment :gorets))))


### PR DESCRIPTION
In an organization where lots of teams and apps
are using statsd, it is important to prefix
stats to keep them separate, but a pain to
repeat this prefix in every stat in your app.
This lets you define it (optionally) in one place.

The format I use in my work is "team.app.hostname."
