### PR TITLE
Allow port to be string, prevent silent failures

### DIFF
--- a/src/clj_statsd.clj
+++ b/src/clj_statsd.clj
@@ -19,7 +19,7 @@
   (send sockagt #(or % (DatagramSocket.)))
   (swap! cfg #(or % (merge {:random (Random.)
                             :host   (InetAddress/getByName host)
-                            :port   port}
+                            :port   (if (integer? port) port (Integer/parseInt port))}
                            (apply hash-map opts)))))
 
 (defn send-stat 


### PR DESCRIPTION
In setup, if passed port is not an integer, attempt to parse it with
Integer/parseInt. Without this, if port was specified as a string,
the library will silently fail when instantiating DatagramPacket and
nothing gets sent to the statsd server.

Allows for more flexible configuration, ie

``` clojure
(apply s/setup (clojure.string/split "localhost:5725" #":"))
```
