### PR TITLE
Support decimal counters

### DIFF
--- a/src/clj_statsd.clj
+++ b/src/clj_statsd.clj
@@ -59,7 +59,7 @@
   with a 1.0 rate"
   ([k]        (increment k 1 1.0))
   ([k v]      (increment k v 1.0))
-  ([k v rate] (publish (format "%s:%d|c" (name k) v) rate)))
+  ([k v rate] (publish (format "%s:%s|c" (name k) v) rate)))
 
 (defn timing
   "Time an event at specified rate, defaults to 1.0 rate"

--- a/test/clj_statsd/test.clj
+++ b/test/clj_statsd/test.clj
@@ -22,7 +22,9 @@
     (increment :gorets)
     (increment "gorets", 1))
   (should-send-expected-stat "gorets:7|c" 1 1
-    (increment :gorets 7)))
+    (increment :gorets 7))
+  (should-send-expected-stat "gorets:1.1|c" 1 1
+    (increment :gorets 1.1)))
 
 (deftest should-send-decrement
   (should-send-expected-stat "gorets:-1|c" 3 3
@@ -30,7 +32,9 @@
     (decrement :gorets)
     (decrement "gorets", 1))
   (should-send-expected-stat "gorets:-7|c" 1 1
-    (decrement :gorets 7)))
+    (decrement :gorets 7))
+  (should-send-expected-stat "gorets:-1.1|c" 1 1
+    (decrement :gorets 1.1)))
 
 (deftest should-send-gauge
   (should-send-expected-stat "gaugor:333|g" 3 3


### PR DESCRIPTION
Statsd supports decimal counters, but the format function in `increment` expected an integer.
