### PR TITLE
Support sub-millisecond timings

### DIFF
--- a/src/clj_statsd.clj
+++ b/src/clj_statsd.clj
@@ -30,7 +30,7 @@
     (catch Exception e
       socket)))
 
-(defn send-stat 
+(defn send-stat
   "Send a raw metric over the network."
   [^String content]
   (when-let [packet (try
@@ -64,7 +64,7 @@
 (defn timing
   "Time an event at specified rate, defaults to 1.0 rate"
   ([k v]      (timing k v 1.0))
-  ([k v rate] (publish (format "%s:%d|ms" (name k) v) rate)))
+  ([k v rate] (publish (format "%s:%f|ms" (name k) (double v)) rate)))
 
 (defn decrement
   "Decrement a counter at specified rate, defaults to a one decrement
@@ -87,9 +87,9 @@
 (defmacro with-sampled-timing
   "Time the execution of the provided code, with sampling."
   [k rate & body]
-  `(let [start# (System/currentTimeMillis)
+  `(let [start# (System/nanoTime)
          result# (do ~@body)]
-    (timing ~k (- (System/currentTimeMillis) start#) ~rate)
+    (timing ~k (/ (- (System/nanoTime) start#) 1000000) ~rate)
     result#))
 
 (defmacro with-timing

--- a/test/clj_statsd/test.clj
+++ b/test/clj_statsd/test.clj
@@ -50,12 +50,12 @@
     (unique :unique 765)))
 
 (deftest should-send-timing-with-default-rate
-  (should-send-expected-stat "glork:320|ms" 2 2
-    (timing "glork" 320)  
+  (should-send-expected-stat "glork:320.000000|ms" 2 2
+    (timing "glork" 320)
     (timing :glork 320)))
 
 (deftest should-send-timing-with-provided-rate
-  (should-send-expected-stat "glork:320|ms|@0.990000" 1 10
+  (should-send-expected-stat "glork:320.000000|ms|@0.990000" 1 10
     (dotimes [n 10] (timing "glork" 320 0.99))))
 
 (deftest should-not-send-stat-without-cfg


### PR DESCRIPTION
Sending the timing value as a string (instead of as a decimal integer) allows for more precise values to be sent to statsd. Operations that take less than a millisecond can now be observed & reported using this library. 
- Send timing values as raw strings (instead of integers) to support small values
- Use `System/nanoTime` in `with-sampled-timing` & `with-timing`
  nanoTime should provide greater sub-millisecond accuracy
