### PR TITLE
Tags used by dogstats

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,6 @@
-(defproject shmish111/clj-statsd "0.3.11"
+(defproject shmish111/clj-statsd "0.4.0"
   :description "statsd protocol client"
   :url         "https://github.com/shmish111/clj-statsd"
-  :dependencies [[org.clojure/clojure "1.4.0"]])
+  :license {:name "MIT License"
+            :url "https://opensource.org/licenses/MIT"}
+  :dependencies [[org.clojure/clojure "1.8.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-statsd "0.3.11"
+(defproject shmish111/clj-statsd "0.3.11"
   :description "statsd protocol client"
-  :url         "https://github.com/pyr/clj-statsd"
+  :url         "https://github.com/shmish111/clj-statsd"
   :dependencies [[org.clojure/clojure "1.4.0"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject shmish111/clj-statsd "0.4.0"
+(defproject clj-statsd "0.4.0"
   :description "statsd protocol client"
   :url         "https://github.com/shmish111/clj-statsd"
   :license {:name "MIT License"

--- a/src/clj_statsd.clj
+++ b/src/clj_statsd.clj
@@ -47,15 +47,17 @@
 (defn publish
   "Send a metric over the network, based on the provided sampling rate.
   This should be a fully formatted statsd metric line."
-  [^String content rate tags]
-  (let [prefix (:prefix @cfg)
-        with-prefix (if prefix (str prefix content) content)
-        with-rate (cond
-                    (nil? @cfg) nil
-                    (>= rate 1.0) with-prefix
-                    (<= (.nextDouble ^Random (:random @cfg)) rate) (format "%s|@%f" with-prefix rate))
-        with-tags (if (not-empty tags) (format "%s|#%s" with-rate (str/join "," tags)) with-rate)]
-    (when @cfg (send-stat with-tags))))
+  ([^String content rate]
+   (publish content rate []))
+  ([^String content rate tags]
+   (let [prefix (:prefix @cfg)
+         with-prefix (if prefix (str prefix content) content)
+         with-rate (cond
+                     (nil? @cfg) nil
+                     (>= rate 1.0) with-prefix
+                     (<= (.nextDouble ^Random (:random @cfg)) rate) (format "%s|@%f" with-prefix rate))
+         with-tags (if (not-empty tags) (format "%s|#%s" with-rate (str/join "," tags)) with-rate)]
+     (when @cfg (send-stat with-tags)))))
 
 (defn increment
   "Increment a counter at specified rate, defaults to a one increment

--- a/test/clj_statsd/test.clj
+++ b/test/clj_statsd/test.clj
@@ -24,7 +24,11 @@
   (should-send-expected-stat "gorets:7|c" 1 1
     (increment :gorets 7))
   (should-send-expected-stat "gorets:1.1|c" 1 1
-    (increment :gorets 1.1)))
+    (increment :gorets 1.1))
+  (should-send-expected-stat "gorets:1.1|c" 1 1
+    (increment :gorets 1.1 2))
+  (should-send-expected-stat "gorets:1.1|c|#tag1,tag2" 1 1
+    (increment :gorets 1.1 2 ["tag1" "tag2"])))
 
 (deftest should-send-decrement
   (should-send-expected-stat "gorets:-1|c" 3 3
@@ -34,7 +38,11 @@
   (should-send-expected-stat "gorets:-7|c" 1 1
     (decrement :gorets 7))
   (should-send-expected-stat "gorets:-1.1|c" 1 1
-    (decrement :gorets 1.1)))
+    (decrement :gorets 1.1))
+  (should-send-expected-stat "gorets:-1.1|c" 1 1
+    (decrement :gorets 1.1 2))
+  (should-send-expected-stat "gorets:-1.1|c|#tag1,tag2" 1 1
+    (decrement :gorets 1.1 2 ["tag1" "tag2"])))
 
 (deftest should-send-gauge
   (should-send-expected-stat "gaugor:333|g" 3 3
@@ -42,7 +50,11 @@
     (gauge :gaugor 333)
     (gauge "gaugor" 333 1))
   (should-send-expected-stat "guagor:1.1|g" 1 1
-    (gauge :guagor 1.1)))
+    (gauge :guagor 1.1))
+  (should-send-expected-stat "guagor:1.1|g" 1 1
+    (gauge :guagor 1.1 2))
+  (should-send-expected-stat "guagor:1.1|g|#tag1,tag2" 1 1
+    (gauge :guagor 1.1 2 ["tag1" "tag2"])))
 
 (deftest should-send-unique
   (should-send-expected-stat "unique:765|s" 2 2
@@ -52,7 +64,10 @@
 (deftest should-send-timing-with-default-rate
   (should-send-expected-stat "glork:320|ms" 2 2
     (timing "glork" 320)  
-    (timing :glork 320)))
+    (timing :glork 320))
+  (should-send-expected-stat "glork:320|ms|#tag1,tag2" 2 2
+    (timing "glork" 320 1 ["tag1" "tag2"])
+    (timing :glork 320 1 ["tag1" "tag2"])))
 
 (deftest should-send-timing-with-provided-rate
   (should-send-expected-stat "glork:320|ms|@0.990000" 1 10


### PR DESCRIPTION
Not sure what you think about this. I had to fork your repo so that I could use 'tags' in dogstats. It's an extension to statsd so in a way it doesn't fit into your library, then again it seems a bit pointless having a fork.