### PR TITLE
Improve timing macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,30 @@ An Example
 
 Here is a snippet showing the use of clj-statsd:
 
-    (ns testing
-        (:require [clj-statsd :as s]))
+```clojure
+(ns testing
+    (:require [clj-statsd :as s]))
 
-    (s/setup "127.0.0.1" 8125)
+(s/setup "127.0.0.1" 8125)
 
-    (s/increment :some_counter)         ; simple increment
-    (s/decrement "some_other_counter")  ; simple decrement
-    (s/increment :some_counter 2)       ; double increment
-    (s/increment :some_counter 2 0.1)   ; sampled double increment
+(s/increment :some_counter)             ; simple increment
+(s/decrement "some_other_counter")      ; simple decrement
+(s/increment :some_counter 2)           ; double increment
+(s/increment :some_counter 2 0.1)       ; sampled double increment
 
-    (s/timing :timing_value 300)        ; record 300ms for "timing_value"
+(s/timing :timing_value 300)            ; record 300ms for "timing_value"
 
-    (s/gauge :current_value 42)         ; record an arbitrary value
+(s/gauge :current_value 42)             ; record an arbitrary value
+
+(s/with-timing :some_slow_code          ; time (some-slow-code) and then
+ (some-slow-code))                      ; send the result using s/timing
+
+(s/with-sampled-timing :slow_code 1.0   ; Like s/with-timing but with
+ (slow-code)                            ; a sample rate.
+
+(s/with-tagged-timing :slow 1.0 ["foo"] ; Like s/with-timing but with
+ (slow)                                 ; a sample rate and tags.
+```
 
 Buckets can be strings or keywords. For more information please refer to
 [statsd](https://github.com/etsy/statsd)


### PR DESCRIPTION
- We no longer lose timing data when the code being timed throws an exception.
- Added `with-tagged-timing` which allows the use of tags while timing some code.
- By using `System/nanoTime` rather than `System/currentTimeMillis` the timing is now unaffected by changes to the local clock (e.g. with NTP)
- Documented the timing macros.